### PR TITLE
Replace FlyCI runners with GH runners

### DIFF
--- a/.github/workflows/ci-macos-arm.yml
+++ b/.github/workflows/ci-macos-arm.yml
@@ -10,7 +10,7 @@ jobs:
         arch: [ arm64 ]
 
     name: build-macos-${{ matrix.arch }}
-    runs-on: flyci-macos-large-latest-m1
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).